### PR TITLE
remove tesseract binaries from DockerFile for pytorch and tensorflow (deep learning images, not for OCR)

### DIFF
--- a/overlays/ps-cv-pytorch/Dockerfile
+++ b/overlays/ps-cv-pytorch/Dockerfile
@@ -37,25 +37,6 @@ RUN tar -xzf leptonica-1.76.0.tar.gz --no-same-owner -C /opt/app-root/ &&\
   make install &&\
   cd
 
-# Install Tesseract from Source
-RUN wget -q https://github.com/tesseract-ocr/tesseract/archive/3.05.02.tar.gz -O 3.05.02.tar.gz
-RUN tar -zxvf 3.05.02.tar.gz -C /opt/app-root/ &&\
-  dnf install -y libtool &&\
-  cd /opt/app-root/tesseract-3.05.02 &&\
-  ./autogen.sh &&\
-  PKG_CONFIG_PATH=/usr/local/lib/pkgconfig LIBLEPT_HEADERSDIR=/usr/local/include ./configure --with-extra-includes=/usr/local/include --with-extra-libraries=/usr/local/lib &&\
-  LDFLAGS="-L/usr/local/lib" CFLAGS="-I/usr/local/include" make &&\
-  make install &&\
-  ldconfig &&\
-  cd &&\
-
-  #Download and install tesseract language files
-  wget https://github.com/tesseract-ocr/tessdata/raw/3.04.00/fin.traineddata &&\
-  wget https://github.com/tesseract-ocr/tessdata/raw/3.04.00/swe.traineddata &&\
-  wget https://github.com/tesseract-ocr/tessdata/raw/3.04.00/eng.traineddata &&\
-  mv *.traineddata /usr/local/share/tessdata &&\
-  ln -s /opt/tesseract-3.05.01 /opt/tesseract-latest
-
 # Install binary needed for open-cv
 RUN dnf install -y mesa-libGL
 

--- a/overlays/ps-cv-tensorflow/Dockerfile
+++ b/overlays/ps-cv-tensorflow/Dockerfile
@@ -24,38 +24,6 @@ ENV THAMOS_RUNTIME_ENVIRONMENT="ps-cv-tensorflow" \
 
 USER root
 
-# Install binary needed for pytesseract
-RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-
-# Install Leptonica from Source
-RUN  wget -q http://www.leptonica.org/source/leptonica-1.76.0.tar.gz -O leptonica-1.76.0.tar.gz
-RUN tar -xzf leptonica-1.76.0.tar.gz --no-same-owner -C /opt/app-root/ &&\
-  cd /opt/app-root/leptonica-1.76.0 &&\
-  ./autobuild &&\
-  ./configure &&\
-  make &&\
-  make install &&\
-  cd
-
-# Install Tesseract from Source
-RUN wget -q https://github.com/tesseract-ocr/tesseract/archive/3.05.02.tar.gz -O 3.05.02.tar.gz
-RUN tar -zxvf 3.05.02.tar.gz -C /opt/app-root/ &&\
-  dnf install -y libtool &&\
-  cd /opt/app-root/tesseract-3.05.02 &&\
-  ./autogen.sh &&\
-  PKG_CONFIG_PATH=/usr/local/lib/pkgconfig LIBLEPT_HEADERSDIR=/usr/local/include ./configure --with-extra-includes=/usr/local/include --with-extra-libraries=/usr/local/lib &&\
-  LDFLAGS="-L/usr/local/lib" CFLAGS="-I/usr/local/include" make &&\
-  make install &&\
-  ldconfig &&\
-  cd &&\
-
-  #Download and install tesseract language files
-  wget https://github.com/tesseract-ocr/tessdata/raw/3.04.00/fin.traineddata &&\
-  wget https://github.com/tesseract-ocr/tessdata/raw/3.04.00/swe.traineddata &&\
-  wget https://github.com/tesseract-ocr/tessdata/raw/3.04.00/eng.traineddata &&\
-  mv *.traineddata /usr/local/share/tessdata &&\
-  ln -s /opt/tesseract-3.05.01 /opt/tesseract-latest
-
 # Install binary needed for open-cv
 RUN dnf install -y mesa-libGL
 


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

Tesseract binaries are not required for pytorch and tensorflow images.